### PR TITLE
fix(inspectors): change .inspector views to .sheet views

### DIFF
--- a/HWS/Projects/16-24/GuessTheFlag.swift
+++ b/HWS/Projects/16-24/GuessTheFlag.swift
@@ -19,7 +19,7 @@ struct GuessTheFlag: View {
     @State private var scoreTitle = ""
     @State private var score: Int = 0
     @State private var tries: Int = 0
-    @State private var inspectorShown = false
+    @State private var isPresenting = false
 
     var body: some View {
         ZStack {
@@ -78,11 +78,10 @@ struct GuessTheFlag: View {
                 Spacer()
 
                 Button {
-                    inspectorShown = true
+                    isPresenting = true
                 } label: {
-                    Label("Inspector", systemImage: "info.circle.fill")
+                    Label("Source Code", systemImage: "info.circle.fill")
                 }
-                .buttonStyle(.borderedProminent)
 
             }
             .padding()
@@ -99,15 +98,24 @@ struct GuessTheFlag: View {
                 Text("Your score is \(score)")
             }
         }
-
-        .inspector(isPresented: $inspectorShown) {
-            ScrollView {
-                CodeText(CodeSnippets.guessTheFlag)
-                    .highlightLanguage(.swift)
-                    .codeTextColors(.theme(.xcode))
+        .sheet(isPresented: $isPresenting) {
+            NavigationStack {
+                ScrollView {
+                    CodeText(CodeSnippets.weSplit)
+                        .highlightLanguage(.swift)
+                        .codeTextColors(.theme(.xcode))
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Close", systemImage: "xmark") {
+                                    isPresenting = false
+                                }
+                            }
+                        }
+                        .navigationTitle("Source Code")
+                }
+                .padding()
+                .font(.callout)
             }
-            .padding()
-            .font(.callout)
         }
     }
 

--- a/HWS/Projects/16-24/TempConvert.swift
+++ b/HWS/Projects/16-24/TempConvert.swift
@@ -44,7 +44,7 @@ struct TempConvert: View {
         return convertedValue
     }
 
-    @State private var inspectorShown = false
+    @State private var isPresenting = false
 
     var body: some View {
         NavigationStack {
@@ -90,26 +90,34 @@ struct TempConvert: View {
             .navigationTitle("TempConvert")
             .toolbar {
                 Button {
-                    inspectorShown = true
+                    isPresenting = true
                 } label: {
-                    Label("Inspector", systemImage: "info.circle.fill")
+                    Label("Source Code", systemImage: "info.circle.fill")
                 }
-                .buttonStyle(.borderedProminent)
                 if temperatureFieldIsFocused {
                     Button("Done", systemImage: "checkmark") {
                         temperatureFieldIsFocused = false
                     }
                 }
             }
-
-            .inspector(isPresented: $inspectorShown) {
-                ScrollView {
-                    CodeText(CodeSnippets.tempConvert)
-                        .highlightLanguage(.swift)
-                        .codeTextColors(.theme(.xcode))
+            .sheet(isPresented: $isPresenting) {
+                NavigationStack {
+                    ScrollView {
+                        CodeText(CodeSnippets.tempConvert)
+                            .highlightLanguage(.swift)
+                            .codeTextColors(.theme(.xcode))
+                            .toolbar {
+                                ToolbarItem(placement: .cancellationAction) {
+                                    Button("Close", systemImage: "xmark") {
+                                        isPresenting = false
+                                    }
+                                }
+                            }
+                            .navigationTitle("Source Code")
+                    }
+                    .padding()
+                    .font(.callout)
                 }
-                .padding()
-                .font(.callout)
             }
         }
     }

--- a/HWS/Projects/16-24/WeSplit.swift
+++ b/HWS/Projects/16-24/WeSplit.swift
@@ -13,7 +13,7 @@ struct WeSplit: View {
     @State private var numberOfPeople = 0
     @State private var tipPercentage = 20
     @FocusState private var amountIsFocused: Bool
-    @State private var inspectorShown = false
+    @State private var isPresenting = false
 
     let tipPercentages = [10, 15, 20, 25, 0]
 
@@ -95,25 +95,34 @@ struct WeSplit: View {
             .navigationTitle("WeSplit")
             .toolbar {
                 Button {
-                    inspectorShown = true
+                    isPresenting = true
                 } label: {
-                    Label("Inspector", systemImage: "info.circle.fill")
+                    Label("Source Code", systemImage: "info.circle.fill")
                 }
-                .buttonStyle(.borderedProminent)
                 if amountIsFocused {
                     Button("Done", systemImage: "checkmark") {
                         amountIsFocused = false
                     }
                 }
             }
-            .inspector(isPresented: $inspectorShown) {
-                ScrollView {
-                    CodeText(CodeSnippets.weSplit)
-                        .highlightLanguage(.swift)
-                        .codeTextColors(.theme(.xcode))
+            .sheet(isPresented: $isPresenting) {
+                NavigationStack {
+                    ScrollView {
+                        CodeText(CodeSnippets.weSplit)
+                            .highlightLanguage(.swift)
+                            .codeTextColors(.theme(.xcode))
+                            .toolbar {
+                                ToolbarItem(placement: .cancellationAction) {
+                                    Button("Close", systemImage: "xmark") {
+                                        isPresenting = false
+                                    }
+                                }
+                            }
+                            .navigationTitle("Source Code")
+                    }
+                    .padding()
+                    .font(.callout)
                 }
-                .padding()
-                .font(.callout)
             }
         }
     }


### PR DESCRIPTION
In **iOS 26 beta 6**, .inspector views are to be partially deprecated for iOS and iPadOS and are not working correctly. To ensure further compatibility, all are changed for .sheet views and dismiss button and title are added for better visual experience.